### PR TITLE
Including IP and TCP source and dest address and port info in filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ because you don't need to reread entire PCAP for each tcp stream.
 tshark -X lua_script:tcp-stream-splitter.lua -X lua_script1:very-big-file.pcap -n -r very-big-file.pcap
 ```
 
-Output files will be stored by pattern `$PWD/very-big-file.pcap.parts/$TCP_STREAM_ID.pcap`.
+Output files will be stored by pattern `$PWD/very-big-file.pcap.parts/$CLIENT_IP-$CLIENT_PORT_$SERVER_IP-$SERVER_PORT_$TCP_STREAM_ID.pcap`.
 
 # Hints
 
 If there's a lot concurrent tcp streams in one big PCAP you may avoid [fail with to many opened file descriptor](https://github.com/strizhechenko/tshark-tcp-stream-splitter/issues/1) by set ulimit to maximal available value:
 
 ```
-ulimit -n 2048
+ulimit -n 4096
 ```
 
 If there's a really lot of streams probably nothing will help you. You can use shell-script above (and add some "parallelism) with python/coproc) and have nice cup of coffee. If you can suggest an better solution of this problem feel free to open an issue or send pull request.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Output files will be stored by pattern `$PWD/very-big-file.pcap.parts/$CLIENT_IP
 
 If there's a lot concurrent tcp streams in one big PCAP you may avoid [fail with to many opened file descriptor](https://github.com/strizhechenko/tshark-tcp-stream-splitter/issues/1) by set ulimit to maximal available value:
 
+MacOS:
+
+```
+ulimit -n 2048
+```
+
+Some linux may allow bigger value:
+
 ```
 ulimit -n 4096
 ```

--- a/tcp-stream-splitter.lua
+++ b/tcp-stream-splitter.lua
@@ -8,6 +8,9 @@ do
     local tcp_fin_f = Field.new("tcp.flags.fin")
     local tcp_rst_f = Field.new("tcp.flags.reset")
     local src_addr_f = Field.new("ip.src")
+    local src_port_f = Field.new("tcp.srcport")
+    local dst_addr_f = Field.new("ip.dst")
+    local dst_port_f = Field.new("tcp.dstport")
 
     local function init_listener()
         local SYN = 2
@@ -24,11 +27,14 @@ do
         function tap.packet()
             local tcp_stream = assert(tonumber(tostring(tcp_stream_f())))
             local src_addr = assert(tostring(src_addr_f()))
+            local src_port = assert(tostring(src_port_f()))
+            local dst_addr = assert(tostring(dst_addr_f()))
+            local dst_port = assert(tostring(dst_port_f()))
             local syn = tonumber(tostring(tcp_syn_f()))
             local index = tcp_stream + 1
             local part_pcap
             if streams_table[index] == nil then
-                part_pcap = string.format("%s.parts/%d.pcap", pcap_file, index)
+                part_pcap = string.format("%s.parts/%s-%s_%s-%s_%d.pcap", pcap_file, src_addr, src_port, dst_addr, dst_port, index)
                 streams_table[index] = {
                     dumper = nil,
                     corrupted = not (syn == 1),


### PR DESCRIPTION
Thank you for the stream splitter. I added some IP info to the filename to make it useful for my use cases, sending you a pull request in case you want to include it.